### PR TITLE
S3 leak fix

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/BSONFileInputFormat.java
+++ b/core/src/main/java/com/mongodb/hadoop/BSONFileInputFormat.java
@@ -44,9 +44,7 @@ public class BSONFileInputFormat extends FileInputFormat {
     public RecordReader createRecordReader(final InputSplit split, final TaskAttemptContext context)
         throws IOException, InterruptedException {
 
-        BSONFileRecordReader reader = new BSONFileRecordReader();
-        reader.initialize(split, context);
-        return reader;
+        return new BSONFileRecordReader();
     }
 
     public static PathFilter getInputPathFilter(final JobContext context) {

--- a/core/src/main/java/com/mongodb/hadoop/splitter/BSONSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/BSONSplitter.java
@@ -111,6 +111,8 @@ public class BSONSplitter extends Configured implements Tool {
             BSONObject splitInfo = (BSONObject) callback.get();
             splits.add(createFileSplitFromBSON(splitInfo, fs, inputFile));
         }
+        fsDataStream.close();
+        fs.close();
         splitsList = splits;
     }//}}}
 


### PR DESCRIPTION

Found this PR dying over on mongo-hadoop and it fixes the issue I've seen. This way we can read directly from S3 and avoid the HDFS intermediate. 